### PR TITLE
Update 2022-09-05-TT-deploy.md (Fixing instructional error)

### DIFF
--- a/_posts/2022-09-05-TT-deploy.md
+++ b/_posts/2022-09-05-TT-deploy.md
@@ -103,7 +103,6 @@ $ ./mvnw package
 
 * Run Java Application
 ```bash
-$ cd
 $ java -jar target/spring-0.0.1-SNAPSHOT.jar
 ```
 


### PR DESCRIPTION
There is an instruction that tells you to run SNAPSHOT.jar in root directory, but it needs to be ran in the newly cloned repo instead.